### PR TITLE
[FIX][distribution_list]CSS was not correcly loaded

### DIFF
--- a/distribution_list/__openerp__.py
+++ b/distribution_list/__openerp__.py
@@ -60,9 +60,6 @@ This module provide features to allow the user to
     'qweb': [
        'static/src/xml/filter_selection.xml',
     ],
-    'css': [
-        'static/src/css/oe_save_only.css',
-    ],
     'demo': [
         'demo/distribution_list_demo.xml',
     ],

--- a/distribution_list/distribution_list_view.xml
+++ b/distribution_list/distribution_list_view.xml
@@ -9,6 +9,7 @@
         <!-- Include JS file for the custom view to select domain from filters -->
         <template id="assets_backend" name="filter_selection" inherit_id="web.assets_backend">
             <xpath expr="." position="inside">
+                <link rel="stylesheet" href="/distribution_list/static/src/css/oe_save_only.css"/>
                 <script type="text/javascript" src="/distribution_list/static/src/js/filter_selection.js"></script>
             </xpath>
         </template>


### PR DESCRIPTION
In V8 `CSS` and `JS` are now declare by adding them into a `view.xml` and no more into the `__openerp__.py`.
Fix this for `distribution_list` module.
