### PR TITLE
[IMP] extract ir_noupdate_override from settings_improvements

### DIFF
--- a/ir_noupdate_override/__init__.py
+++ b/ir_noupdate_override/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import ir_model_data

--- a/ir_noupdate_override/__openerp__.py
+++ b/ir_noupdate_override/__openerp__.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of ir_noupdate_override, an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     ir_noupdate_override is free software: you can redistribute it and/or
+#     modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     ir_noupdate_override is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with ir_noupdate_override.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "ir_noupdate_override",
+
+    'summary': """
+        Override noupdate setting in addons.""",
+
+    'description': """
+        When installed, this module let developers
+        create addons that override records that have
+        been set noupdate=1.
+
+        This is particularly useful to force the modification
+        of default record rules by addons.
+    """,
+
+    'author': "ACSONE SA/NV",
+    'website': "http://acsone.eu",
+    'license': 'AGPL-3',
+
+    'category': 'Uncategorized',
+    'version': '0.1',
+
+    'depends': ['base'],
+
+    'data': [
+    ],
+
+    'demo': [
+    ],
+}

--- a/ir_noupdate_override/ir_model_data.py
+++ b/ir_noupdate_override/ir_model_data.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of ir_noupdate_override, an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     ir_noupdate_override is free software: you can redistribute it and/or
+#     modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     ir_noupdate_override is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with ir_noupdate_override.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models
+
+
+class ir_model_data(models.Model):
+
+    _inherit = 'ir.model.data'
+
+    def _update(self, cr, uid, model, module, values,
+                xml_id=False, store=True, noupdate=False,
+                mode='init', res_id=False,
+                context=None):
+        '''
+        Let's the developer to decide if a record is updatable or not
+        I.e force the init mode if the data tag is marked noupdate="0"
+        '''
+        if not noupdate and mode == 'update':
+            mode = 'init'
+        res = super(ir_model_data, self)._update(
+            cr, uid, model, module, values,
+            xml_id=xml_id, store=store, noupdate=noupdate,
+            mode=mode, res_id=res_id,
+            context=context)
+        return res

--- a/settings_improvement/__openerp__.py
+++ b/settings_improvement/__openerp__.py
@@ -39,6 +39,7 @@
     "category": "Other",
     "depends": [
         "base",
+        "ir_noupdate_override",
     ],
     "description": """
 Settings Improvement

--- a/settings_improvement/__openerp__.py
+++ b/settings_improvement/__openerp__.py
@@ -1,30 +1,24 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-# Authors: Stéphane Bidoul & Olivier Laurent
-# Copyright (c) 2012 Acsone SA/NV (http://www.acsone.eu)
-# All Rights Reserved
+#     This file is part of settings_improvements, an Odoo module.
 #
-# WARNING: This program as such is intended to be used by professional
-# programmers who take the whole responsibility of assessing all potential
-# consequences resulting from its eventual inadequacies and bugs.
-# End users who are looking for a ready-to-use solution with commercial
-# guarantees and support are strongly advised to contact a Free Software
-# Service Company.
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
 #
-# This program is Free Software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
+#     settings_improvements is free software: you can redistribute it and/or
+#     modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
+#     settings_improvements is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with settings_improvements.
+#     If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
 

--- a/settings_improvement/ir_actions.py
+++ b/settings_improvement/ir_actions.py
@@ -1,29 +1,24 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-# Copyright (c) 2014 Acsone SA/NV (http://www.acsone.eu)
-# All Rights Reserved
+#     This file is part of settings_improvements, an Odoo module.
 #
-# WARNING: This program as such is intended to be used by professional
-# programmers who take the whole responsibility of assessing all potential
-# consequences resulting from its eventual inadequacies and bugs.
-# End users who are looking for a ready-to-use solution with commercial
-# guarantees and support are strongly advised to contact a Free Software
-# Service Company.
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
 #
-# This program is Free Software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
+#     settings_improvements is free software: you can redistribute it and/or
+#     modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
+#     settings_improvements is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with settings_improvements.
+#     If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
 

--- a/settings_improvement/ir_model.py
+++ b/settings_improvement/ir_model.py
@@ -1,29 +1,24 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-# Copyright (c) 2014 Acsone SA/NV (http://www.acsone.eu)
-# All Rights Reserved
+#     This file is part of settings_improvements, an Odoo module.
 #
-# WARNING: This program as such is intended to be used by professional
-# programmers who take the whole responsibility of assessing all potential
-# consequences resulting from its eventual inadequacies and bugs.
-# End users who are looking for a ready-to-use solution with commercial
-# guarantees and support are strongly advised to contact a Free Software
-# Service Company.
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
 #
-# This program is Free Software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
+#     settings_improvements is free software: you can redistribute it and/or
+#     modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
+#     settings_improvements is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with settings_improvements.
+#     If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
 
@@ -45,27 +40,3 @@ class ir_model(orm.Model):
             pass
 
         return True
-
-
-class ir_model_data(orm.Model):
-
-    _inherit = 'ir.model.data'
-
-# private methods
-
-    def _update(self, cr, uid, model, module, values,
-                xml_id=False, store=True, noupdate=False,
-                mode='init', res_id=False,
-                context=None):
-        '''
-        Let's the developer to decide if a record is updatable or not
-        I.e force the init mode if the data tag is marked noupdate="0"
-        '''
-        if not noupdate and mode == 'update':
-            mode = 'init'
-        res = super(ir_model_data, self)._update(
-            cr, uid, model, module, values,
-            xml_id=xml_id, store=store, noupdate=noupdate,
-            mode=mode, res_id=res_id,
-            context=context)
-        return res

--- a/settings_improvement/res_users.py
+++ b/settings_improvement/res_users.py
@@ -1,29 +1,24 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-# Copyright (c) 2014 Acsone SA/NV (http://www.acsone.eu)
-# All Rights Reserved
+#     This file is part of settings_improvements, an Odoo module.
 #
-# WARNING: This program as such is intended to be used by professional
-# programmers who take the whole responsibility of assessing all potential
-# consequences resulting from its eventual inadequacies and bugs.
-# End users who are looking for a ready-to-use solution with commercial
-# guarantees and support are strongly advised to contact a Free Software
-# Service Company.
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
 #
-# This program is Free Software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
+#     settings_improvements is free software: you can redistribute it and/or
+#     modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
+#     settings_improvements is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with settings_improvements.
+#     If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
 

--- a/settings_improvement/workflow.py
+++ b/settings_improvement/workflow.py
@@ -1,29 +1,24 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-# Copyright (c) 2014 Acsone SA/NV (http://www.acsone.eu)
-# All Rights Reserved
+#     This file is part of settings_improvements, an Odoo module.
 #
-# WARNING: This program as such is intended to be used by professional
-# programmers who take the whole responsibility of assessing all potential
-# consequences resulting from its eventual inadequacies and bugs.
-# End users who are looking for a ready-to-use solution with commercial
-# guarantees and support are strongly advised to contact a Free Software
-# Service Company.
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
 #
-# This program is Free Software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
+#     settings_improvements is free software: you can redistribute it and/or
+#     modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
+#     settings_improvements is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with settings_improvements.
+#     If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
 


### PR DESCRIPTION
- extract ir_noupdate_override from settings_improvements, first step in splitting settings_improvements in modules with orthogonal features
- make settings_improvements depends on ir_noupdate_override for backwards compatibility
- fix settings_improvements headers (AGPL 3 instead of GPL 2)
