### PR TITLE
[8.0][FIX][distribution_list] empty primary complex results are wrongly handled

### DIFF
--- a/distribution_list/distribution_list.py
+++ b/distribution_list/distribution_list.py
@@ -241,22 +241,26 @@ class distribution_list(orm.Model):
         optionally filtered by an extra domain and/or
         ordered by a given sort criteria
         Final result is a list of unique values (sorted or not)
+        If no target field is given the initial ids list is returned
         """
         res_ids = []
-        if ids and model and fld:
-            domain = [('id', 'in', ids), (fld, '!=', False)]
-            domain += dom or []
+        if ids and model:
+            if not fld:
+                res_ids = ids
+            else:
+                domain = [('id', 'in', ids), (fld, '!=', False)]
+                domain += dom or []
 
-            vals = self.pool[model].search_read(
-                cr, uid, domain, fields=[fld], order=sort, context=context)
-            if vals:
-                # extract id of fld
-                for val in vals:
-                    if isinstance(val[fld], tuple):
-                        res_ids.append(val[fld][0])
-                    else:
-                        res_ids.append(val[fld])
-            res_ids = self._order_del(cr, uid, res_ids, context=context)
+                vals = self.pool[model].search_read(
+                    cr, uid, domain, fields=[fld], order=sort, context=context)
+                if vals:
+                    # extract id of fld
+                    for val in vals:
+                        if isinstance(val[fld], tuple):
+                            res_ids.append(val[fld][0])
+                        else:
+                            res_ids.append(val[fld])
+                res_ids = self._order_del(cr, uid, res_ids, context=context)
 
         return res_ids
 
@@ -295,7 +299,7 @@ class distribution_list(orm.Model):
                 cr, uid, res_ids, model,
                 context.get('field_main_object'),
                 context.get('more_filter'),
-                sort, context=context) or res_ids
+                sort, context=context)
 
             alternative_ids = self._get_ids(
                 cr, uid, res_ids, model,

--- a/distribution_list/tests/test_distribution_list.py
+++ b/distribution_list/tests/test_distribution_list.py
@@ -494,6 +494,23 @@ class test_distribution_list(common.TransactionCase):
         self.assertTrue(len(res_ids) == 2,
                         'Should have 2 ids if no `more_filter`')
 
+        context['more_filter'] = [('name', '=', 'x23')]
+        res_ids, alt_ids = distri_list_obj.get_complex_distribution_list_ids(
+            cr, SUPERUSER_ID, [dl], context=context)
+        self.assertFalse(
+            res_ids, 'With a "noway" domain and a target field name, '
+                     'should return no result')
+
+        context.pop('field_main_object')
+        primary_ids = distri_list_obj.get_ids_from_distribution_list(
+            cr, SUPERUSER_ID, [dl], context=context)
+        res_ids, alt_ids = distri_list_obj.get_complex_distribution_list_ids(
+            cr, SUPERUSER_ID, [dl], context=context)
+        self.assertTrue(
+            res_ids == primary_ids,
+            'With no target field name, should return '
+            'the same result as `get_ids_from_distribution_list`')
+
     def test_duplicate_distribution_list_and_filters(self):
         """
         Test the duplication (copy) of a distribution list and a filter


### PR DESCRIPTION
It's a side effect of my previous refactorization: when a valid target field is given, an empty primary result **MUST** return an empty result not the primary result list of ids.
