### PR TITLE
Distribution List and filter Results

### DIFF
--- a/distribution_list/distribution_list.py
+++ b/distribution_list/distribution_list.py
@@ -380,7 +380,7 @@ class distribution_list(orm.Model):
                 'views': [(False, 'tree')],
                 'context': context,
                 'domain': domain,
-                'target': 'new',
+                'target': 'current',
                 }
 
 
@@ -503,7 +503,7 @@ class distribution_list_line(orm.Model):
                 'views': [(False, 'tree')],
                 'context': context,
                 'domain': current_filter.domain,
-                'target': 'new',
+                'target': 'current',
                 }
 
     def action_partner_selection(self, cr, uid, ids, context=None):

--- a/distribution_list/tests/test_distribution_list.py
+++ b/distribution_list/tests/test_distribution_list.py
@@ -599,8 +599,6 @@ class test_distribution_list(common.TransactionCase):
             cr, uid, distribution_list_id, context=context)
         self.assertEqual(vals['type'], 'ir.actions.act_window',
                          "Should be an ir.actions.act_window ")
-        self.assertEqual(vals['target'], 'new',
-                         "Should be an popup window to avoid lost of focus")
         self.assertEqual(vals['res_model'], 'mail.compose.message',
                          "This mass mailing is made with mail composer")
         # test context content
@@ -639,5 +637,3 @@ class test_distribution_list(common.TransactionCase):
                          "Should be an ir.actions.act_window ")
         self.assertEqual(vals['res_model'], 'res.partner',
                          "Model should be the same than the distribution list")
-        self.assertEqual(vals['target'], 'new',
-                         "Should be an popup window to avoid lost of focus")

--- a/distribution_list/tests/test_distribution_list_line.py
+++ b/distribution_list/tests/test_distribution_list_line.py
@@ -130,5 +130,3 @@ class test_distribution_list_line(common.TransactionCase):
                          "Should be an ir.actions.act_window ")
         self.assertEqual(vals['res_model'], 'res.partner',
                          "Model should be the same than the distribution list")
-        self.assertEqual(vals['target'], 'new',
-                         "Should be an popup window to avoid lost of focus")


### PR DESCRIPTION
Open distribution list and filter result action in current windows and not in modal window anymore.

This will allow csv export.
