### PR TITLE
[RFC] use the classic way to '_inheritS' from 'mail.alias'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: false
+cache: pip
+
 language: python
 
 python:
@@ -8,25 +11,23 @@ addons:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml # because pip installation is slow
-      - python-simplejson
-      - python-serial
 env:
   global:
   - VERSION="8.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
 
   matrix:
   - LINT_CHECK="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="mass_mailing_distribution_list"
-  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="mass_mailing_distribution_list"
+  - TESTS="1" ODOO_REPO="odoo/odoo"
+  - TESTS="1" ODOO_REPO="OCA/OCB"
 
 virtualenv:
   system_site_packages: true
 
 install:
+  - pip install anybox.testing.openerp
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
-  - pip install xlrd anybox.testing.openerp pytz babel
 
 script:
   - travis_run_tests

--- a/distribution_list/distribution_list.py
+++ b/distribution_list/distribution_list.py
@@ -414,6 +414,7 @@ class distribution_list_line(orm.Model):
         self.pool.get('res.company')._company_default_get(
             cr, uid, 'distribution.list.line', context=c),
         'domain': "[]",
+
         'src_model_id': lambda self, cr, uid, c:
             self.pool.get('ir.model').search(
             cr, uid, [('model', '=', 'res.partner')], limit=1, context=c)[0],

--- a/distribution_list/wizard/mail_compose_message.py
+++ b/distribution_list/wizard/mail_compose_message.py
@@ -41,11 +41,12 @@ class mail_compose_message(orm.TransientModel):
         """
         if context is None:
             context = {}
-        ctx = context.copy()
         if 'distribution_list_id' in vals:
             if 'active_domain' in context:
+                context = dict(context, {
+                    'mail.compose.message.mode': 'mass_mail',
+                })
                 del(context['active_domain'])
-                ctx['mail.compose.message.mode'] = 'mass_mail'
                 if 'use_active_domain' in vals:
                     vals['use_active_domain'] = False
         return super(mail_compose_message, self).create(
@@ -70,14 +71,13 @@ class mail_compose_message(orm.TransientModel):
         """
         if context is None:
             context = {}
-        ctx = context.copy()
         wizard = self.browse(cr, uid, ids, context=context)[0]
         if wizard.distribution_list_id and \
                 not context.get('dl_computed', False):
             res_ids, _ = self.get_distribution_list_ids(
                 cr, uid, [wizard.distribution_list_id.id], context=context)
-            ctx['active_ids'] = res_ids
+            context = dict(context, active_ids=res_ids)
             # do not send mail to an empty list of recipients
             ids = res_ids and ids or []
         return super(mail_compose_message, self).send_mail(
-            cr, uid, ids, context=ctx)
+            cr, uid, ids, context=context)

--- a/mass_mailing_distribution_list/__openerp__.py
+++ b/mass_mailing_distribution_list/__openerp__.py
@@ -25,7 +25,7 @@
 ##############################################################################
 {
     'name': 'Mass Mailing Distribution List',
-    'version': '1.0',
+    'version': '1.1',
     'author': 'ACSONE SA/NV',
     'maintainer': 'ACSONE SA/NV',
     'website': 'http://www.acsone.eu',

--- a/mass_mailing_distribution_list/i18n/fr.po
+++ b/mass_mailing_distribution_list/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-03-05 23:22+0000\n"
-"PO-Revision-Date: 2015-03-05 23:22+0000\n"
+"POT-Creation-Date: 2015-07-31 12:30+0000\n"
+"PO-Revision-Date: 2015-07-31 12:30+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,15 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: mass_mailing_distribution_list
-#: view:distribution.list:mass_mailing_distribution_list.distribution_list_search
-msgid "Allow Mail Forwarding"
-msgstr "Permet le transfert de courriels"
+#: code:addons/mass_mailing_distribution_list/distribution_list.py:244
+#, python-format
+msgid "%s+copy"
+msgstr "%s+copie"
+
+#. module: mass_mailing_distribution_list
+#: constraint:distribution.list:0
+msgid "An alias is mandatory for mail forwarding, forbidden otherwise"
+msgstr "Un pseudonyme est requis pour le transfert de courriels, interdit sinon"
 
 #. module: mass_mailing_distribution_list
 #: help:distribution.list,message_last_post:0
@@ -33,13 +39,19 @@ msgid "Distribution List"
 msgstr "Liste de distribution"
 
 #. module: mass_mailing_distribution_list
+#: view:distribution.list:mass_mailing_distribution_list.distribution_list_form
+#: field:distribution.list,alias_id:0
+msgid "Email Alias"
+msgstr "Pseudonyme"
+
+#. module: mass_mailing_distribution_list
 #: model:ir.model,name:mass_mailing_distribution_list.model_mail_compose_message
 msgid "Email composition wizard"
 msgstr "Fenêtre de composition de courriel"
 
 #. module: mass_mailing_distribution_list
-#: code:addons/mass_mailing_distribution_list/distribution_list.py:285
-#: code:addons/mass_mailing_distribution_list/distribution_list.py:318
+#: code:addons/mass_mailing_distribution_list/distribution_list.py:64
+#: code:addons/mass_mailing_distribution_list/distribution_list.py:375
 #, python-format
 msgid "Error"
 msgstr "Erreur"
@@ -60,6 +72,11 @@ msgid "If checked new messages require your attention."
 msgstr "Si coché, de nouveaux messages requièrent votre attention."
 
 #. module: mass_mailing_distribution_list
+#: help:distribution.list,alias_id:0
+msgid "Internal email associated with this distribution list. Incoming emails will be automatically forwarded to all recipients of the distribution list."
+msgstr "Adresse courriel à usage interne associée à cette liste de distribution. Les courriels entrants seront automatiquement transférés vers tous les destinataires de la liste."
+
+#. module: mass_mailing_distribution_list
 #: field:distribution.list,message_is_follower:0
 msgid "Is a Follower"
 msgstr "Est abonné"
@@ -70,11 +87,7 @@ msgid "Last Message Date"
 msgstr "Date du dernier message"
 
 #. module: mass_mailing_distribution_list
-#: field:distribution.list,mail_alias_id:0
-msgid "Mail Alias"
-msgstr "Pseudonyme"
-
-#. module: mass_mailing_distribution_list
+#: view:distribution.list:mass_mailing_distribution_list.distribution_list_search
 #: field:distribution.list,mail_forwarding:0
 msgid "Mail Forwarding"
 msgstr "Transfert de courriels"
@@ -100,7 +113,7 @@ msgid "Messages and communication history"
 msgstr "Historique des messages et communications"
 
 #. module: mass_mailing_distribution_list
-#: code:addons/mass_mailing_distribution_list/distribution_list.py:285
+#: code:addons/mass_mailing_distribution_list/distribution_list.py:375
 #, python-format
 msgid "Mode \"%s\" is not a valid mode"
 msgstr "Le mode \"%s\" n'est pas un mode valide"
@@ -139,9 +152,9 @@ msgid "Partner Path"
 msgstr "Chemin vers contact"
 
 #. module: mass_mailing_distribution_list
-#: code:addons/mass_mailing_distribution_list/distribution_list.py:319
+#: code:addons/mass_mailing_distribution_list/distribution_list.py:65
 #, python-format
-msgid "Please contact your Administrator to configure a \"catchall\" email alias"
+msgid "Please contact your Administrator to configure a \"catchall\" mail alias"
 msgstr "Veuillez contacter votre administrateur pour configurer un pseudonyme du type \"catchall\""
 
 #. module: mass_mailing_distribution_list

--- a/mass_mailing_distribution_list/i18n/mass_mailing_distribution_list.pot
+++ b/mass_mailing_distribution_list/i18n/mass_mailing_distribution_list.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-03-05 23:20+0000\n"
-"PO-Revision-Date: 2015-03-05 23:20+0000\n"
+"POT-Creation-Date: 2015-07-31 12:28+0000\n"
+"PO-Revision-Date: 2015-07-31 12:28+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,8 +16,14 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: mass_mailing_distribution_list
-#: view:distribution.list:mass_mailing_distribution_list.distribution_list_search
-msgid "Allow Mail Forwarding"
+#: code:addons/mass_mailing_distribution_list/distribution_list.py:244
+#, python-format
+msgid "%s+copy"
+msgstr ""
+
+#. module: mass_mailing_distribution_list
+#: constraint:distribution.list:0
+msgid "An alias is mandatory for mail forwarding, forbidden otherwise"
 msgstr ""
 
 #. module: mass_mailing_distribution_list
@@ -33,13 +39,19 @@ msgid "Distribution List"
 msgstr ""
 
 #. module: mass_mailing_distribution_list
+#: view:distribution.list:mass_mailing_distribution_list.distribution_list_form
+#: field:distribution.list,alias_id:0
+msgid "Email Alias"
+msgstr ""
+
+#. module: mass_mailing_distribution_list
 #: model:ir.model,name:mass_mailing_distribution_list.model_mail_compose_message
 msgid "Email composition wizard"
 msgstr ""
 
 #. module: mass_mailing_distribution_list
-#: code:addons/mass_mailing_distribution_list/distribution_list.py:285
-#: code:addons/mass_mailing_distribution_list/distribution_list.py:318
+#: code:addons/mass_mailing_distribution_list/distribution_list.py:64
+#: code:addons/mass_mailing_distribution_list/distribution_list.py:375
 #, python-format
 msgid "Error"
 msgstr ""
@@ -60,6 +72,11 @@ msgid "If checked new messages require your attention."
 msgstr ""
 
 #. module: mass_mailing_distribution_list
+#: help:distribution.list,alias_id:0
+msgid "Internal email associated with this distribution list. Incoming emails will be automatically forwarded to all recipients of the distribution list."
+msgstr ""
+
+#. module: mass_mailing_distribution_list
 #: field:distribution.list,message_is_follower:0
 msgid "Is a Follower"
 msgstr ""
@@ -70,11 +87,7 @@ msgid "Last Message Date"
 msgstr ""
 
 #. module: mass_mailing_distribution_list
-#: field:distribution.list,mail_alias_id:0
-msgid "Mail Alias"
-msgstr ""
-
-#. module: mass_mailing_distribution_list
+#: view:distribution.list:mass_mailing_distribution_list.distribution_list_search
 #: field:distribution.list,mail_forwarding:0
 msgid "Mail Forwarding"
 msgstr ""
@@ -100,7 +113,7 @@ msgid "Messages and communication history"
 msgstr ""
 
 #. module: mass_mailing_distribution_list
-#: code:addons/mass_mailing_distribution_list/distribution_list.py:285
+#: code:addons/mass_mailing_distribution_list/distribution_list.py:375
 #, python-format
 msgid "Mode \"%s\" is not a valid mode"
 msgstr ""
@@ -139,9 +152,9 @@ msgid "Partner Path"
 msgstr ""
 
 #. module: mass_mailing_distribution_list
-#: code:addons/mass_mailing_distribution_list/distribution_list.py:319
+#: code:addons/mass_mailing_distribution_list/distribution_list.py:65
 #, python-format
-msgid "Please contact your Administrator to configure a \"catchall\" email alias"
+msgid "Please contact your Administrator to configure a \"catchall\" mail alias"
 msgstr ""
 
 #. module: mass_mailing_distribution_list

--- a/mass_mailing_distribution_list/migrations/1.1/pre-migration.py
+++ b/mass_mailing_distribution_list/migrations/1.1/pre-migration.py
@@ -1,0 +1,17 @@
+# -*- encoding: utf-8 -*-
+import logging
+
+__name__ = 'Renaming column "mail_alias_id" to "alias_id"'
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        # it is the installation of the module
+        return
+    SQL_QUERY = '''
+    ALTER TABLE
+        distribution_list
+    RENAME COLUMN mail_alias_id TO alias_id
+    '''
+    cr.execute(SQL_QUERY)

--- a/mass_mailing_distribution_list/views/distribution_list_view.xml
+++ b/mass_mailing_distribution_list/views/distribution_list_view.xml
@@ -2,21 +2,18 @@
 <openerp>
     <data noupdate="0">
 
-        <!-- DISTRIBUTION LIST -->
-
         <!-- SEARCH -->
         <record id="distribution_list_search" model="ir.ui.view">
             <field name="name">distribution.list.search (mass_mailing_distribution_list)</field>
             <field name="model">distribution.list</field>
-            <field name="inherit_id"
-                ref="distribution_list.distribution_list_search" />
+            <field name="inherit_id" ref="distribution_list.distribution_list_search" />
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='name']" position="after">
-                    <field name="mail_alias_id" />
+                    <field name="alias_name" />
                     <filter name="newsletter" string="Newsletters"
                         domain="[('newsletter','=',True)]" />
                     <separator/>
-                    <filter name="mail_forwarding" string="Allow Mail Forwarding"
+                    <filter name="mail_forwarding" string="Mail Forwarding"
                         domain="[('mail_forwarding','=',True)]" />
                 </xpath>
             </field>
@@ -28,10 +25,9 @@
             <field name="model">distribution.list</field>
             <field name="inherit_id" ref="distribution_list.distribution_list_tree" />
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='dst_model_id']"
-                    position="after">
+                <xpath expr="//field[@name='dst_model_id']" position="after">
                     <field name="newsletter" />
-                    <field name="mail_forwarding"/>
+                    <field name="alias_name"/>
                 </xpath>
             </field>
         </record>
@@ -42,48 +38,52 @@
             <field name="model">distribution.list</field>
             <field name="inherit_id" ref="distribution_list.distribution_list_form" />
             <field name="arch" type="xml">
-
-                <xpath expr="//field[@name='dst_model_id']"
-                    position="after">
+                <xpath expr="//field[@name='dst_model_id']" position="after">
                     <field name="newsletter" />
-                    <field name="mail_forwarding"/>
                 </xpath>
 
-                <xpath expr="//field[@name='bridge_field']"
-                    position="after">
+                <xpath expr="//field[@name='bridge_field']" position="after">
                     <field name="partner_path"
-                        attrs="{'invisible': [('mail_forwarding', '=', 'False')],
-                                'required':[('newsletter','=', True)]}" />
-                    <field name="mail_alias_id"
-                        attrs="{'invisible': ['|',
-                                                ('mail_forwarding', '=', False),
-                                                ('mail_alias_id', '=', False),]}"/>
+                           attrs="{'invisible': [('mail_forwarding', '=', 'False')],
+                                   'required':[('newsletter','=', True)]}" />
                 </xpath>
 
-                <!-- Add user tree into distribution list form -->
-                <xpath expr="//group[@name='filters']" position="after">
-                    <div attrs="{'invisible': [('newsletter', '=', False)]}">
-                        <group name="opt">
-                            <div name="opt_in">
-                                <separator string="Opt-In" />
-                                <field name="opt_in_ids">
-                                    <tree string="Opt-In">
-                                        <field name="display_name" />
-                                        <field name="email" />
-                                    </tree>
-                                </field>
+                <xpath expr="//group[@name='info']" position="inside">
+                    <group>
+                        <field name="mail_forwarding"
+                               on_change="onchange_mail_forwarding(mail_forwarding, name, alias_name)"/>
+                    </group>
+                    <group name="group_alias"
+                           attrs="{'invisible': ['|',('alias_domain', '=', False),('mail_forwarding', '=', False)]}">
+                        <label for="alias_name" string="Email Alias"/>
+                        <div name="alias_def">
+                            <field name="alias_id" class="oe_read_only oe_inline"
+                                    string="Email Alias" required="0"/>
+                            <div class="oe_edit_only oe_inline" name="edit_alias" style="display: inline;" >
+                                <field name="alias_name" class="oe_inline"
+                                       attrs="{'required': [('mail_forwarding', '=', True)]}"/>@<field name="alias_domain" class="oe_inline" readonly="1"/>
                             </div>
-                            <div name="opt_out">
-                                <separator string="Opt-Out" />
-                                <field name="opt_out_ids">
-                                    <tree string="Opt-Out">
-                                        <field name="display_name" />
-                                        <field name="email" />
-                                    </tree>
-                                </field>
-                            </div>
-                        </group>
-                    </div>
+                        </div>
+                    </group>
+                </xpath>
+
+                <xpath expr="//notebook" position="inside">
+                    <page name="optin" string="Opt-In" attrs="{'invisible': [('newsletter', '=', False)]}">
+                        <field name="opt_in_ids">
+                            <tree>
+                                <field name="display_name" />
+                                <field name="email" />
+                            </tree>
+                        </field>
+                    </page>
+                    <page name="opout" string="Opt-Out" attrs="{'invisible': [('newsletter', '=', False)]}">
+                        <field name="opt_out_ids">
+                            <tree>
+                                <field name="display_name" />
+                                <field name="email" />
+                            </tree>
+                        </field>
+                    </page>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
[FIX] allow to no more create the alias from a function field (that launched an infinite recursion on the orm and crashed all tests in acsone-addons)
