### PR TITLE
[8.0] Add hr timesheet no closed project

### DIFF
--- a/hr_timesheet_no_closed_project_task/README.rst
+++ b/hr_timesheet_no_closed_project_task/README.rst
@@ -1,6 +1,8 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License AGPL-3
 
+===================================
 HR Timesheet No Closed Project-Task
 ===================================
 

--- a/hr_timesheet_no_closed_project_task/README.rst
+++ b/hr_timesheet_no_closed_project_task/README.rst
@@ -1,0 +1,35 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License AGPL-3
+
+HR Timesheet No Closed Project-Task
+===================================
+
+This module depends on https://github.com/odoo/odoo/pull/8186
+
+This module prevents to select closed project or task on timesheet line.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/acsone/acsone-addons/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/acsone/acsone-addons/issues/new?body=module:%20hr_timesheet_no_closed_project_task%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Stéphane Bidoul <stephane.bidoul@acsone.eu>
+* Adrien Peiffer <adrien.peiffer@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: https://www.acsone.eu/logo.png
+   :alt: ACSONE SA/NV
+   :target: http://www.acsone.eu
+
+This module is maintained by ACSONE SA/NV.

--- a/hr_timesheet_no_closed_project_task/__init__.py
+++ b/hr_timesheet_no_closed_project_task/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/hr_timesheet_no_closed_project_task/__openerp__.py
+++ b/hr_timesheet_no_closed_project_task/__openerp__.py
@@ -43,6 +43,7 @@
         'views/hr_analytic_timesheet_view.xml',
         'views/hr_timesheet_sheet_view.xml',
         'views/project_task_view.xml',
+        'views/hr_timesheet_no_closed_project_task.xml',
     ],
     "license": "AGPL-3",
     "installable": True,

--- a/hr_timesheet_no_closed_project_task/__openerp__.py
+++ b/hr_timesheet_no_closed_project_task/__openerp__.py
@@ -39,6 +39,7 @@
     ],
     "data": [
         'security/ir.model.access.csv',
+        'security/hr_timesheet_no_closed_project_task_security.xml',
         'views/hr_analytic_timesheet_view.xml',
         'views/hr_timesheet_sheet_view.xml',
         'views/project_task_view.xml',

--- a/hr_timesheet_no_closed_project_task/__openerp__.py
+++ b/hr_timesheet_no_closed_project_task/__openerp__.py
@@ -35,7 +35,7 @@
     "depends": [
         "hr_timesheet_task",
         "hr_timesheet_invoice",
-        "account_analytic_project_id",
+        "account_analytic_project",
     ],
     "data": [
         'security/ir.model.access.csv',

--- a/hr_timesheet_no_closed_project_task/__openerp__.py
+++ b/hr_timesheet_no_closed_project_task/__openerp__.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of hr_timesheet_no_closed_project_task,
+#     an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     hr_timesheet_invoice_hide_to_invoice is free software:
+#     you can redistribute it and/or modify it under the terms of the GNU
+#     Affero General Public License as published by the Free Software
+#     Foundation,either version 3 of the License, or (at your option) any
+#     later version.
+#
+#     hr_timesheet_invoice_hide_to_invoice is distributed
+#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#     PURPOSE.  See the GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the GNU Affero General Public License
+#     along with hr_timesheet_no_closed_project_task.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    "name": "HR Timesheet No Closed Project-Task",
+    'summary': """
+        Prevent to select closed project or task on timesheet line""",
+    "version": "8.0.1.0.0",
+    "author": "ACSONE SA/NV",
+    "maintainer": "ACSONE SA/NV",
+    "website": "http://www.acsone.eu",
+    "category": "Human Resources",
+    "depends": [
+        "hr_timesheet_task",
+        "hr_timesheet_invoice",
+        "account_analytic_project_id",
+    ],
+    "data": [
+        'security/ir.model.access.csv',
+        'views/hr_analytic_timesheet_view.xml',
+        'views/hr_timesheet_sheet_view.xml',
+        'views/project_task_view.xml',
+    ],
+    "license": "AGPL-3",
+    "installable": True,
+}

--- a/hr_timesheet_no_closed_project_task/models/__init__.py
+++ b/hr_timesheet_no_closed_project_task/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import project_task

--- a/hr_timesheet_no_closed_project_task/models/__init__.py
+++ b/hr_timesheet_no_closed_project_task/models/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import project_task
+from . import hr_timesheet_line

--- a/hr_timesheet_no_closed_project_task/models/hr_timesheet_line.py
+++ b/hr_timesheet_no_closed_project_task/models/hr_timesheet_line.py
@@ -23,20 +23,20 @@
 #
 ##############################################################################
 
-from openerp import models, fields
-
-PROJECT_SELECTION = [('template', 'Template'),
-                     ('draft', 'New'),
-                     ('open', 'In Progress'),
-                     ('cancelled', 'Cancelled'),
-                     ('pending', 'Pending'),
-                     ('close', 'Closed')]
+from openerp import models, api
 
 
-class ProjectTask(models.Model):
-    _inherit = 'project.task'
+class HrAnalyticTimesheet(models.Model):
+    _inherit = "hr.analytic.timesheet"
+    _name = "hr.analytic.timesheet"
 
-    stage_closed = fields.Boolean(related='stage_id.closed', string='Closed')
-    project_state = fields.Selection(PROJECT_SELECTION,
-                                     related='project_id.state',
-                                     string='Project State')
+    @api.multi
+    def on_change_account_id(self, account_id, user_id=False):
+        res = super(HrAnalyticTimesheet, self)\
+            .on_change_account_id(account_id=account_id, user_id=user_id)
+        if res.get('value') and res['value'].get('task_id'):
+            task_id = res['value']['task_id']
+            task = self.env['project.task'].browse([task_id])
+            if task.stage_id.closed:
+                res['value'].pop('task_id')
+        return res

--- a/hr_timesheet_no_closed_project_task/models/project_task.py
+++ b/hr_timesheet_no_closed_project_task/models/project_task.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+##############################################################################
+#
+#    Authors: Adrien Peiffer
+#    Copyright (c) 2015 Acsone SA/NV (http://www.acsone.eu)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields
+
+PROJECT_SELECTION = [('template', 'Template'),
+                     ('draft', 'New'),
+                     ('open', 'In Progress'),
+                     ('cancelled', 'Cancelled'),
+                     ('pending', 'Pending'),
+                     ('close', 'Closed')]
+
+
+class ProjectTask(models.Model):
+    _inherit = 'project.task'
+
+    stage_closed = fields.Boolean(related='stage_id.closed', string='Closed')
+    project_state = fields.Selection(PROJECT_SELECTION,
+                                     related='project_id.state',
+                                     string='Project State')

--- a/hr_timesheet_no_closed_project_task/security/hr_timesheet_no_closed_project_task_security.xml
+++ b/hr_timesheet_no_closed_project_task/security/hr_timesheet_no_closed_project_task_security.xml
@@ -1,0 +1,13 @@
+<openerp>
+    <data>
+        <record id="timesheet_line_closed_project_task" model="ir.rule">
+            <field name="name">Prevent to use a closed task or analytic account on timesheet line</field>
+            <field name="model_id" ref="hr_timesheet.model_hr_analytic_timesheet"/>
+            <field name="domain_force">['|', ('task_id', '=', False), ('task_id.stage_id.closed', '!=', True),('account_id.project_ids.state', 'not in', ('close', 'cancelled'))]</field>
+            <field name="perm_read"   eval="0"/>
+            <field name="perm_write"  eval="1"/>
+            <field name="perm_create" eval="1"/>
+            <field name="perm_unlink" eval="1"/>
+        </record>
+    </data>
+</openerp>

--- a/hr_timesheet_no_closed_project_task/security/hr_timesheet_no_closed_project_task_security.xml
+++ b/hr_timesheet_no_closed_project_task/security/hr_timesheet_no_closed_project_task_security.xml
@@ -1,6 +1,6 @@
 <openerp>
     <data>
-        <record id="timesheet_line_closed_project_task" model="ir.rule">
+<!--         <record id="timesheet_line_closed_project_task" model="ir.rule">
             <field name="name">Prevent to use a closed task or analytic account on timesheet line</field>
             <field name="model_id" ref="hr_timesheet.model_hr_analytic_timesheet"/>
             <field name="domain_force">['|', ('task_id', '=', False), ('task_id.stage_id.closed', '!=', True),('account_id.project_ids.state', 'not in', ('close', 'cancelled'))]</field>
@@ -8,6 +8,6 @@
             <field name="perm_write"  eval="1"/>
             <field name="perm_create" eval="1"/>
             <field name="perm_unlink" eval="1"/>
-        </record>
+        </record> -->
     </data>
 </openerp>

--- a/hr_timesheet_no_closed_project_task/security/ir.model.access.csv
+++ b/hr_timesheet_no_closed_project_task/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_project_task_type_employee,project.task.type employee,project.model_project_task_type,base.group_user,1,0,0,0

--- a/hr_timesheet_no_closed_project_task/static/src/js/timesheet.js
+++ b/hr_timesheet_no_closed_project_task/static/src/js/timesheet.js
@@ -1,0 +1,19 @@
+openerp.hr_timesheet_no_closed_project_task = function(instance) { 
+
+    var module = instance.hr_timesheet_sheet
+
+    module.WeeklyTimesheet = module.WeeklyTimesheet.extend({
+        
+        init_add_account: function() {
+            var self = this
+            this._super.apply(this, arguments);
+            self.account_m2o.node.attrs.domain.push(['project_ids.state', 'not in', ['close', 'cancelled']]);
+            self.task_m2o.node.attrs.domain.push(['stage_id.closed', '!=', true]);
+        },
+        onchange_account_id: function() {
+            var self = this
+            this._super.apply(this, arguments);
+            self.task_m2o.node.attrs.domain.push(['stage_id.closed', '!=', true]);
+        }
+    });
+};

--- a/hr_timesheet_no_closed_project_task/views/hr_analytic_timesheet_view.xml
+++ b/hr_timesheet_no_closed_project_task/views/hr_analytic_timesheet_view.xml
@@ -10,7 +10,7 @@
                     <attribute name="domain">[('project_id.analytic_account_id','=',account_id),('stage_id.closed', '!=', True)]</attribute>
                 </xpath>
                 <xpath expr="//field[@name='account_id']" position="attributes">
-                    <attribute name="domain">[('type','=','normal'),('state', '&lt;&gt;', 'close'),('parent_id','!=',False),('project_id.state', 'not in', ('close', 'cancelled'))]</attribute>
+                    <attribute name="domain">[('type','=','normal'),('state', '&lt;&gt;', 'close'),('parent_id','!=',False),('project_ids.state', 'not in', ('close', 'cancelled'))]</attribute>
                 </xpath>
             </field>
         </record>
@@ -30,7 +30,7 @@
             <field name="inherit_id" ref="hr_timesheet_invoice.hr_timesheet_line_tree2"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='account_id']" position="attributes">
-                    <attribute name="domain">[('type','in',['normal','contract']),('state', '&lt;&gt;', 'close'),('use_timesheets','=',1),'|', ('project_id', '=', False), ('project_id.state', 'not in', ('close', 'cancelled'))]</attribute>
+                    <attribute name="domain">[('type','in',['normal','contract']),('state', '&lt;&gt;', 'close'),('use_timesheets','=',1),'|', ('project_ids', '=', False), ('project_ids.state', 'not in', ('close', 'cancelled'))]</attribute>
                 </xpath>
             </field>
         </record>

--- a/hr_timesheet_no_closed_project_task/views/hr_analytic_timesheet_view.xml
+++ b/hr_timesheet_no_closed_project_task/views/hr_analytic_timesheet_view.xml
@@ -1,0 +1,38 @@
+<openerp>
+    <data>
+        <!-- Add task on hr.analytic.timesheet -->
+        <record id="hr_timesheet_line_form" model="ir.ui.view">
+            <field name="name">hr.analytic.timesheet.form (hr_timesheet_no_closed_project_task)</field>
+            <field name="model">hr.analytic.timesheet</field>
+            <field name="inherit_id" ref="hr_timesheet_task.hr_timesheet_line_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='task_id']" position="attributes">
+                    <attribute name="domain">[('project_id.analytic_account_id','=',account_id),('stage_id.closed', '!=', True)]</attribute>
+                </xpath>
+                <xpath expr="//field[@name='account_id']" position="attributes">
+                    <attribute name="domain">[('type','=','normal'),('state', '&lt;&gt;', 'close'),('parent_id','!=',False),('project_id.state', 'not in', ('close', 'cancelled'))]</attribute>
+                </xpath>
+            </field>
+        </record>
+        <record id="hr_timesheet_line_tree" model="ir.ui.view">
+            <field name="name">hr.analytic.timesheet.tree (hr_timesheet_no_closed_project_task)</field>
+            <field name="model">hr.analytic.timesheet</field>
+            <field name="inherit_id" ref="hr_timesheet_task.hr_timesheet_line_tree"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='task_id']" position="attributes">
+                    <attribute name="domain">[('project_id.analytic_account_id','=',account_id),('stage_id.closed', '!=', True)]</attribute>
+                </xpath>
+            </field>
+        </record>
+        <record id="hr_timesheet_line_tree2" model="ir.ui.view">
+            <field name="name">hr.analytic.timesheet.tree (hr_timesheet_no_closed_project_task)</field>
+            <field name="model">hr.analytic.timesheet</field>
+            <field name="inherit_id" ref="hr_timesheet_invoice.hr_timesheet_line_tree2"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='account_id']" position="attributes">
+                    <attribute name="domain">[('type','in',['normal','contract']),('state', '&lt;&gt;', 'close'),('use_timesheets','=',1),'|', ('project_id', '=', False), ('project_id.state', 'not in', ('close', 'cancelled'))]</attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/hr_timesheet_no_closed_project_task/views/hr_timesheet_no_closed_project_task.xml
+++ b/hr_timesheet_no_closed_project_task/views/hr_timesheet_no_closed_project_task.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <template id="assets_backend" name="timesheet" inherit_id="web.assets_backend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/hr_timesheet_no_closed_project_task/static/src/js/timesheet.js"></script>
+            </xpath>
+        </template>
+    </data>
+</openerp>

--- a/hr_timesheet_no_closed_project_task/views/hr_timesheet_sheet_view.xml
+++ b/hr_timesheet_no_closed_project_task/views/hr_timesheet_sheet_view.xml
@@ -9,12 +9,12 @@
                 <xpath
                     expr="//field[@name='timesheet_ids']/tree[@string='Timesheet Activities']/field[@name='account_id']"
                     position="attributes">
-                    <attribute name="domain">[('type','in',['normal','contract']),('state', '&lt;&gt;', 'close'),('use_timesheets','=',1),'|', ('project_id', '=', False), ('project_id.state', 'not in', ('close', 'cancelled'))]</attribute>
+                    <attribute name="domain">[('type','in',['normal','contract']),('state', '&lt;&gt;', 'close'),('use_timesheets','=',1),'|', ('project_ids', '=', False), ('project_ids.state', 'not in', ('close', 'cancelled'))]</attribute>
                 </xpath>
                 <xpath
                     expr="//field[@name='timesheet_ids']/form[@string='Timesheet Activities']/field[@name='account_id']"
                     position="attributes">
-                    <attribute name="domain">[('type','in',['normal','contract']),('state', '&lt;&gt;', 'close'),('use_timesheets','=',1),'|', ('project_id', '=', False), ('project_id.state', 'not in', ('close', 'cancelled'))]</attribute>
+                    <attribute name="domain">[('type','in',['normal','contract']),('state', '&lt;&gt;', 'close'),('use_timesheets','=',1),'|', ('project_ids', '=', False), ('project_ids.state', 'not in', ('close', 'cancelled'))]</attribute>
                 </xpath>
                 <xpath
                     expr="//field[@name='timesheet_ids']/tree[@string='Timesheet Activities']/field[@name='task_id']"

--- a/hr_timesheet_no_closed_project_task/views/hr_timesheet_sheet_view.xml
+++ b/hr_timesheet_no_closed_project_task/views/hr_timesheet_sheet_view.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="hr_timesheet_sheet_form">
+            <field name="name">hr.timesheet.sheet.form (hr_timesheet_no_closed_project_task)</field>
+            <field name="model">hr_timesheet_sheet.sheet</field>
+            <field name="inherit_id" ref="hr_timesheet_task.hr_timesheet_sheet_form_with_activity"/>
+            <field name="arch" type="xml">
+                <xpath
+                    expr="//field[@name='timesheet_ids']/tree[@string='Timesheet Activities']/field[@name='account_id']"
+                    position="attributes">
+                    <attribute name="domain">[('type','in',['normal','contract']),('state', '&lt;&gt;', 'close'),('use_timesheets','=',1),'|', ('project_id', '=', False), ('project_id.state', 'not in', ('close', 'cancelled'))]</attribute>
+                </xpath>
+                <xpath
+                    expr="//field[@name='timesheet_ids']/form[@string='Timesheet Activities']/field[@name='account_id']"
+                    position="attributes">
+                    <attribute name="domain">[('type','in',['normal','contract']),('state', '&lt;&gt;', 'close'),('use_timesheets','=',1),'|', ('project_id', '=', False), ('project_id.state', 'not in', ('close', 'cancelled'))]</attribute>
+                </xpath>
+                <xpath
+                    expr="//field[@name='timesheet_ids']/tree[@string='Timesheet Activities']/field[@name='task_id']"
+                    position="attributes">
+                    <attribute name="domain">[('project_id.analytic_account_id','=',account_id),('stage_id.closed', '!=', True)]</attribute>
+                </xpath>
+                <xpath
+                    expr="//field[@name='timesheet_ids']/form[@string='Timesheet Activities']/field[@name='task_id']"
+                    position="attributes">
+                    <attribute name="domain">[('project_id.analytic_account_id','=',account_id),('stage_id.closed', '!=', True)]</attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/hr_timesheet_no_closed_project_task/views/project_task_view.xml
+++ b/hr_timesheet_no_closed_project_task/views/project_task_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_task_form2">
+            <field name="name">project.task.form (hr_timesheet_no_closed_project_task)</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="timesheet_task.view_task_form2"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='work_ids']" position="before">
+                    <field name="stage_closed" invisible="1" />
+                    <field name="project_state" invisible="1" />
+                </xpath>
+               <xpath expr="//field[@name='work_ids']" position="attributes">
+                    <attribute name="attrs">{'readonly': ['|', ('stage_closed', '=', True), ('project_state', 'in', ('close', 'cancelled'))]}</attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,2 +1,3 @@
 account-financial-reporting
 connector
+hr-timesheet


### PR DESCRIPTION
This module prevents to select closed project or task on timesheet line.
- [ ] This module depends on https://github.com/odoo/odoo/pull/8186
- [ ] And on https://github.com/OCA/account-analytic/pull/44
- [x] And on https://github.com/OCA/hr-timesheet/pull/61
